### PR TITLE
Adding shebang comments for macOS

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -22,11 +22,11 @@ def run_file(audio_url, file_name):
 
 # uploads files to get back an upload URL
 print('Uploading files...')
-os.system('upload.py')
+os.system('./upload.py')
 
 # deletes any files in the json or text directories
 print('Emptying folders...')
-os.system('empty_folders.py')
+os.system('./empty_folders.py')
 
 f = open('urls.txt', 'r')
 

--- a/empty_folders.py
+++ b/empty_folders.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 
 

--- a/upload.py
+++ b/upload.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from config import auth_key, endpoint
 import os
 import requests


### PR DESCRIPTION
- Specified that the files called by `os.system` are located in the same directory by prepending them with `./`.
- Added shebang `#!` comments to ensure that `empty_folders.py` and `upload.py` are not called as shell scripts and use the environment's specified version of the Python interpreter.